### PR TITLE
Fix bug caused by mutable keyword arguments

### DIFF
--- a/kbcstorage/base.py
+++ b/kbcstorage/base.py
@@ -134,6 +134,5 @@ class Endpoint:
             joined (:obj:`str`): The parts joined to base by forward slash,
                 eg. 'http://example.com/hello/a/deeper/path'.
         """
-        parts.insert(0, base)
-        return '/'.join([str(part).strip('/') for part in parts if
-                         str(part).strip('/')])
+        return '/'.join([base, *[str(part).strip('/') for part in parts if
+                         str(part).strip('/')]])


### PR DESCRIPTION
This is a bandaid fix, and indeed the bug is indirectly caused by passing a mutable default argument to the `_get`, `_post` etc functions. The result only shows up here because I mutate parts... Ultimately, as well as fixing the mutable default args I think I will remove this whole function in a later commit because the premise is flawed.